### PR TITLE
MSLayerGroup class method updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Sketch Slicer",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Slice helper for Sketch",
 	"main": "index.js",
 	"scripts": {

--- a/slice.sketchplugin/Contents/Sketch/manifest.json
+++ b/slice.sketchplugin/Contents/Sketch/manifest.json
@@ -24,7 +24,7 @@
       "slice-frame"
     ]
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Slice helper for Sketch",
   "homepage": "https://github.com/d4rekanguok/sketch-slicer#readme",
   "name": "Sketch Slicer",

--- a/slice.sketchplugin/Contents/Sketch/slice-frame.js
+++ b/slice.sketchplugin/Contents/Sketch/slice-frame.js
@@ -129,7 +129,7 @@ exports['default'] = Slice = {
 
       var name = layer.name();
       var layers = MSLayerArray.arrayWithLayer(layer);
-      var group = MSLayerGroup.groupFromLayers(layers);
+      var group = MSLayerGroup.groupWithLayers(layers);
       group.setName(name + '_export');
 
       var slice = MSSliceLayer.sliceLayerFromLayer(layer);

--- a/slice.sketchplugin/Contents/Sketch/slice-padding.js
+++ b/slice.sketchplugin/Contents/Sketch/slice-padding.js
@@ -129,7 +129,7 @@ exports['default'] = Slice = {
 
       var name = layer.name();
       var layers = MSLayerArray.arrayWithLayer(layer);
-      var group = MSLayerGroup.groupFromLayers(layers);
+      var group = MSLayerGroup.groupWithLayers(layers);
       group.setName(name + '_export');
 
       var slice = MSSliceLayer.sliceLayerFromLayer(layer);

--- a/src/slice.js
+++ b/src/slice.js
@@ -18,7 +18,7 @@ export default Slice = {
 
     const name = layer.name();
     const layers = MSLayerArray.arrayWithLayer(layer);
-    const group = MSLayerGroup.groupFromLayers(layers);
+    const group = MSLayerGroup.groupWithLayers(layers);
     group.setName(name + '_export');
 
     const slice = MSSliceLayer.sliceLayerFromLayer(layer);


### PR DESCRIPTION
Version Sketch 52.x changed the MSLayerGroup class method of 'groupFromLayers' to 'groupWithLayers'. The change bring the plugin back into working order.